### PR TITLE
save most recent point

### DIFF
--- a/js/LocateButton.js
+++ b/js/LocateButton.js
@@ -327,6 +327,7 @@ function (
                     wkid: 4326
                 }));
                 if (pt) {
+                    this.set('recentPoint', pt);
                     // project point
                     this._projectPoint(pt).then(lang.hitch(this, function(projectedPoint){
                         var evt = this._createEvent(projectedPoint, scale, position);


### PR DESCRIPTION
When the LocateButton errors for some reason, like not being able to project the Point or center the map due to a non-web-mercator spatial reference, it just returns an error and not the position or the created Point that was the issue. It would be convenient to save the most recently geolocated point as a property of the widget. Maybe the raw position would be a better choice, not sure.

This way they end-user can reproject the point as needed and handle centering the map themselves.

Ideally, it would be great if there were cases that instead of `deferred.reject(error)`, it did a `deferred.reject({ position: position, error: new Error("blah blah blah") })`, and then in the event emitter for the error do `evt.error = e.error, evt.position = e.position`. But I decided against trying to implement it at the moment as it looks like there are lots of nested deferreds in the `_locate` chain and I would probably break some internals.

Saving the most recent point seemed like the next best option.
